### PR TITLE
build on windows

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -3,6 +3,6 @@ ARG_ENABLE('blake2', 'blake2 support', 'no');
 if (PHP_BLAKE2 != 'no') {
 	AC_DEFINE('HAVE_BLAKE2', 1, 'blake2 support enabled');
 
-	EXTENSION('blake2', 'php_blake2.c', null, '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
-	ADD_SOURCES('ext/blake2', 'blake2b-ref.c blake2s-ref.c', 'blake2');
+	EXTENSION('blake2', 'php_blake2.c', true, '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
+	ADD_SOURCES(configure_module_dirname, 'blake2b-ref.c blake2s-ref.c', 'blake2');
 }

--- a/php_blake2.c
+++ b/php_blake2.c
@@ -77,7 +77,7 @@ PHP_FUNCTION(blake2)
         RETURN_FALSE;
     }
 
-    char hashOutput[hashByteLength];
+    char* hashOutput = (char*) emalloc(hashByteLength);
 
     int result = blake2b(hashOutput, hashByteLength, data, dataByteLength, key, keyLength);
 
@@ -93,7 +93,7 @@ PHP_FUNCTION(blake2)
         RETURN_STRINGL(hashOutput, hashByteLength, 1);
 #endif
     } else {
-        char hex[hashByteLength * 2 + 1];
+        char* hex = (char*) emalloc(hashByteLength * 2 + 1);
         php_hash_bin2hex(hex, (unsigned char *) hashOutput, hashByteLength);
         hex[hashByteLength * 2] = '\0';
 
@@ -102,7 +102,11 @@ PHP_FUNCTION(blake2)
 #else
         RETURN_STRING(hex, 1);
 #endif
+
+        efree(hex);
     }
+
+    efree(hashOutput);
 }
 
 PHP_FUNCTION(blake2s)
@@ -143,7 +147,7 @@ PHP_FUNCTION(blake2s)
         RETURN_FALSE;
     }
 
-    char hashOutput[hashByteLength];
+    char* hashOutput = (char*) emalloc(hashByteLength);
 
     int result = blake2s(hashOutput, hashByteLength, data, dataByteLength, key, keyLength);
 
@@ -159,7 +163,7 @@ PHP_FUNCTION(blake2s)
         RETURN_STRINGL(hashOutput, hashByteLength, 1);
 #endif
     } else {
-        char hex[hashByteLength * 2 + 1];
+        char* hex = (char*) emalloc(hashByteLength * 2 + 1);
         php_hash_bin2hex(hex, (unsigned char *) hashOutput, hashByteLength);
         hex[hashByteLength * 2] = '\0';
 
@@ -168,5 +172,9 @@ PHP_FUNCTION(blake2s)
 #else
         RETURN_STRING(hex, 1);
 #endif
+
+        efree(hex);
     }
+
+    efree(hashOutput);
 }


### PR DESCRIPTION
Previously it was untested (https://github.com/strawbrary/php-blake2/pull/11#issue-140577688) and had errors like (https://github.com/strawbrary/php-sha3/issues/1). But now i have a successfull build with 7.1/VC14,TS,x86

- wrapper changed to emalloc/efree instead of variable length arrays
- configured to always build as dll on windows
- configure could not find files, used a known var